### PR TITLE
Fix confusing lock icon for the tab lock feature

### DIFF
--- a/src/svelte/TopBar.svelte
+++ b/src/svelte/TopBar.svelte
@@ -225,11 +225,11 @@
       </IconButton>
       {#if $isLocked}
         <IconButton dense on:click={() => unlockAllTab()} title="Unlock tab">
-          <MdiIcon size="24" icon={mdiLockOpenOutline} {color} />
+          <MdiIcon size="24" icon={mdiLockOutline} {color} />
         </IconButton>
       {:else}
         <IconButton dense on:click={() => lockToTab()} title="Lock to tab">
-          <MdiIcon size="24" icon={mdiLockOutline} {color} />
+          <MdiIcon size="24" icon={mdiLockOpenOutline} {color} />
         </IconButton>
       {/if}
       <IconButton


### PR DESCRIPTION
Unfortunately the tab lock icon was confusing to me and my colleagues. I believe it should be closed when visualizing the locked-to-one-tab state.