### PR TITLE
feat:use regular expressions when judging url

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -32,8 +32,12 @@ function passFilters_(url, type, filters) {
           if (allowUrls === undefined) {
             allowUrls = false;
           }
-          if (new RegExp(filter.urlRegex).test(url)) {
-            allowUrls = true;
+          try{
+            if (new RegExp(filter.urlRegex).test(url)) {
+              allowUrls = true;
+            }
+          }catch{
+            allowUrls = false;
           }
           break;
         case 'excludeUrls':
@@ -41,8 +45,12 @@ function passFilters_(url, type, filters) {
           if (allowUrls === undefined) {
             allowUrls = true;
           }
-          if (new RegExp(filter.urlRegex).test(url)) {
-            allowUrls = false;
+          try{
+            if (new RegExp(filter.urlRegex).test(url)) {
+              allowUrls = false;
+            }
+          }catch{
+            allowUrls = true;
           }
           break;
         case 'types':

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -32,7 +32,7 @@ function passFilters_(url, type, filters) {
           if (allowUrls === undefined) {
             allowUrls = false;
           }
-          if (url.search(filter.urlRegex) === 0) {
+          if (new RegExp(filter.urlRegex).test(url)) {
             allowUrls = true;
           }
           break;
@@ -41,7 +41,7 @@ function passFilters_(url, type, filters) {
           if (allowUrls === undefined) {
             allowUrls = true;
           }
-          if (url.search(filter.urlRegex) === 0) {
+          if (new RegExp(filter.urlRegex).test(url)) {
             allowUrls = false;
           }
           break;

--- a/src/js/datasource.js
+++ b/src/js/datasource.js
@@ -103,7 +103,7 @@ export async function addFilter() {
   if (tab && !lodashIsEmpty(tab.url)) {
     const origin = new URL(tab.url).origin;
     if (!lodashIsEmpty(origin) && origin !== 'null') {
-      urlRegex = `${origin}/.*`;
+      urlRegex = origin.replace(/\//g,'\\/');
     }
   }
   const filters = latestProfiles[latestSelectedProfileIndex].filters;


### PR DESCRIPTION
If I want to filter http://github.com 和 https://github.com，I need to write two rules like this。
![image](https://user-images.githubusercontent.com/23151576/96393605-35f5ef80-11f2-11eb-8cda-33617dda17b6.png)

Or I want to exclude all subdomains under a website，I need to emun all subdomains
![image](https://user-images.githubusercontent.com/23151576/96406623-68afe000-1212-11eb-9417-6e6cbfaf28c0.png)

But using regular expressions can solve the above problems well